### PR TITLE
https:// should be http://

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Following is the Write up on how to use the Raspbery Pi Zero W to host a web ser
     1. PS4 Network Connection -> Wifi -> Manual setup
     2. In PS4 find the Wifi Network called PIZero and connect to it using password as password
     3. Rest all value set to Automatic
-6. PS4 -> Browser -> visit https://7.7.7.1
+6. PS4 -> Browser -> visit http://7.7.7.1
 7. Click on load jail break and wait
     1. It will notify WEBKit is sucessfull -> click on ok and wait
     2. A popup will thrown Say USB emulation staterted and wait for ps4 pop up


### PR DESCRIPTION
When running through these instructions, I receive an SSL error when trying to access https://7.7.7.1, but the page loads as expected when accessing http://7.7.7.1, I think it's just a typo in your readme. Thanks much for your hard work! This is a very useful project. 